### PR TITLE
#20: Fix auto-scroll stopping due height changes

### DIFF
--- a/com.chabicht.code-intelligence/src/com/chabicht/code_intelligence/chat/chat-template.html
+++ b/com.chabicht.code-intelligence/src/com/chabicht/code_intelligence/chat/chat-template.html
@@ -503,6 +503,8 @@ function isScrolledToBottom() {
  * @param {String} updatedContent - The new HTML content for the message.
  */
  function updateMessage(uuid, updatedContent) {
+   const scrolledToBottom = isScrolledToBottom();
+
    var message = document.getElementById(uuid);
    if (message) {
      // Find the content div within the message
@@ -528,6 +530,13 @@ function isScrolledToBottom() {
     var scrollPauseButton = document.getElementById("scroll-pause-button");
     if(scrollPauseButton) {
       scrollPauseButton.style.visibility = autoScrollEnabled ? "visible" : "hidden";
+    }
+
+    if (scrolledToBottom && !isScrolledToBottom()) {
+      const bottom = document.getElementById("bottom");
+      if (bottom) {
+        bottom.scrollIntoView({ block: 'start', behaviour: 'instant' });
+      }
     }
 
     updateScrollToBottomButtonVisibility();


### PR DESCRIPTION
As discussed in #20 this fixes a problem with the auto-scrolling stopping when the height of previous elements changes due to commonmark changing HTML tags around.